### PR TITLE
Fixed build issues on recent Java versions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+# Build artifact folders
+target/
+bin/

--- a/plugins/carisma.check.rabac/META-INF/MANIFEST.MF
+++ b/plugins/carisma.check.rabac/META-INF/MANIFEST.MF
@@ -14,3 +14,5 @@ Require-Bundle: org.eclipse.ui,
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ActivationPolicy: lazy
 Export-Package: carisma.check.rabac
+Import-Package: javax.xml.bind;version="2.2.0",
+ javax.xml.bind.annotation;version="2.2.0"

--- a/plugins/carisma.core.io/META-INF/MANIFEST.MF
+++ b/plugins/carisma.core.io/META-INF/MANIFEST.MF
@@ -21,3 +21,4 @@ Require-Bundle: org.apache.httpcomponents.httpcore,
  org.apache.commons.codec
 Bundle-Activator: carisma.core.io.IOActivator
 Bundle-ActivationPolicy: lazy
+Import-Package: javax.xml.bind;version="2.2.0"

--- a/plugins/carisma.core/META-INF/MANIFEST.MF
+++ b/plugins/carisma.core/META-INF/MANIFEST.MF
@@ -41,3 +41,5 @@ Bundle-Vendor: Software Engineering Institute, TU Dortmund
 Require-Bundle: org.eclipse.core.resources,
  org.eclipse.core.runtime,
  org.eclipse.emf.ecore
+Import-Package: javax.xml.bind;version="2.2.0",
+ javax.xml.bind.annotation;version="2.2.0"

--- a/plugins/carisma.profile.umlsec/.classpath
+++ b/plugins/carisma.profile.umlsec/.classpath
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="gen-src">
 		<attributes>
@@ -9,5 +8,6 @@
 	</classpathentry>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="profile"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/plugins/carisma.profile.umlsec/.settings/org.eclipse.jdt.core.prefs
+++ b/plugins/carisma.profile.umlsec/.settings/org.eclipse.jdt.core.prefs
@@ -1,7 +1,7 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.7
-org.eclipse.jdt.core.compiler.compliance=1.7
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.compliance=1.8
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.source=1.7
+org.eclipse.jdt.core.compiler.source=1.8

--- a/plugins/carisma.profile.umlsec/META-INF/MANIFEST.MF
+++ b/plugins/carisma.profile.umlsec/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %pluginName
 Bundle-SymbolicName: carisma.profile.umlsec;singleton:=true
 Bundle-Version: 1.0.6.qualifier
 Bundle-ClassPath: .
-Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.uml2.uml;visibility:=reexport,
  org.eclipse.papyrus.editor,
  org.eclipse.core.runtime,

--- a/plugins/carisma.ui.eclipse/META-INF/MANIFEST.MF
+++ b/plugins/carisma.ui.eclipse/META-INF/MANIFEST.MF
@@ -25,3 +25,4 @@ Export-Package: carisma.ui.eclipse,
 Bundle-Vendor: Software Engineering Institute, TU Dortmund
 Bundle-ClassPath: .,
  xslt/
+Import-Package: javax.xml.bind;version="2.2.0"

--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,11 @@
 			<layout>p2</layout>
 			<url>http://download.eclipse.org/releases/photon</url>
 		</repository>
+		<repository>
+			<id>Eclilpse Photon Orbit</id>
+			<layout>p2</layout>
+			<url>https://download.eclipse.org/tools/orbit/downloads/drops/R20180606145124/repository</url>
+		</repository>
 	</repositories>
   <build>
     <plugins>


### PR DESCRIPTION
I had some minor issues compiling CARiSMA in my Eclipse using recent (>8) java versions, so I decided to propose a fix.
* I increased the required Java version in one bundle to 8 because String::join has been already used. This is only part of Java versions later than 7.
* I added explicit imports for javax.xml.bind.* packages, which is required for Java versions >8.

The downside of the fix is that you have to install the javax.xml.bind bundle from the Eclipse orbit updatesite into your Eclipse. Additionally, you have to include the bundle in your update site. An aggregated update site (see [CBI aggregator](https://wiki.eclipse.org/CBI/aggregator)) might be feasible. Another option would be to include the bundle in a feature. I have done none of these suggestions because I am not sure what you prefer.

The build does not work because of test failures but these tests already failed before my changes.